### PR TITLE
Improve mods search filters, upload validation, and front page listing

### DIFF
--- a/functions/api/upload/index.ts
+++ b/functions/api/upload/index.ts
@@ -4,6 +4,47 @@ type Env = {
   BUNDLES: R2Bucket;
 };
 
+const ALLOWED_SLOTS = new Set([
+  "Body",
+  "Bottoms",
+  "Bust",
+  "Eyes",
+  "Gloves",
+  "Hair",
+  "Hat",
+  "Shoes",
+  "Socks",
+  "Top",
+  "Presets",
+]);
+
+function slugifyTitle(input: string) {
+  return input
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+async function ensureUniqueSlug(db: D1Database, baseSlug: string) {
+  const likePattern = `${baseSlug}-%`;
+  const { results } = await db
+    .prepare(`SELECT slug FROM mods WHERE slug = ? OR slug LIKE ?`)
+    .bind(baseSlug, likePattern)
+    .all();
+
+  const taken = new Set((results as Array<{ slug: string }>).map((row) => row.slug));
+  if (!taken.has(baseSlug)) return baseSlug;
+
+  let suffix = 2;
+  while (taken.has(`${baseSlug}-${suffix}`)) {
+    suffix += 1;
+  }
+  return `${baseSlug}-${suffix}`;
+}
+
 export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   try {
     const formData = await ctx.request.formData();
@@ -11,18 +52,11 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
     // Grab form fields
     const title = formData.get("title")?.toString();
     const description = formData.get("description")?.toString();
-    const slot = formData.get("slot")?.toString();
+    const slotRaw = formData.get("slot")?.toString();
     const creator = formData.get("creator")?.toString();
     const file = formData.get("file") as File | null;
 
-    // Debug log (remove in production)
-    console.log("Got fields:", {
-      title,
-      description,
-      slot,
-      creator,
-      file: file ? file.name : null,
-    });
+    const slot = slotRaw?.trim();
 
     // Validate required fields
     if (!title || !description || !slot || !creator || !file) {
@@ -32,8 +66,28 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       );
     }
 
+    if (!ALLOWED_SLOTS.has(slot)) {
+      return Response.json({ error: `Invalid slot '${slot}'` }, { status: 400 });
+    }
+
+    if (file.size === 0) {
+      return Response.json({ error: "File is empty" }, { status: 400 });
+    }
+
+    const db = ctx.env.DB;
+
+    const creatorRow = await db
+      .prepare(`SELECT id FROM creators WHERE handle = ?`)
+      .bind(creator)
+      .first();
+
+    if (!creatorRow) {
+      return Response.json({ error: `Unknown creator handle '${creator}'` }, { status: 400 });
+    }
+
     // Generate slug from title (lowercase + dash)
-    const slug = title.toLowerCase().replace(/\s+/g, "-");
+    const baseSlug = slugifyTitle(title) || `mod-${Date.now().toString(36)}`;
+    const slug = await ensureUniqueSlug(db, baseSlug);
 
     // Upload file to R2
     const fileKey = `${slot.toLowerCase()}/${slug}/${file.name}`;
@@ -41,18 +95,29 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
 
     // Insert into DB
     const createdAt = new Date().toISOString();
-    await ctx.env.DB.prepare(
-      `INSERT INTO mods (creator_id, slug, title, description, slot) 
-       VALUES ((SELECT id FROM creators WHERE handle=?), ?, ?, ?, ?)`
-    )
-      .bind(creator, slug, title, description, slot)
+    await db
+      .prepare(
+        `INSERT INTO mods (creator_id, slug, title, description, slot)
+         VALUES (?, ?, ?, ?, ?)`
+      )
+      .bind(creatorRow.id, slug, title, description, slot)
       .run();
 
-    await ctx.env.DB.prepare(
-      `INSERT INTO mod_versions (mod_id, version, r2_key, file_size, changelog, created_at)
-       VALUES ((SELECT id FROM mods WHERE slug=?), ?, ?, ?, ?, ?)`
-    )
-      .bind(slug, "1.0.0", fileKey, file.size, "Initial upload", createdAt)
+    const modRow = await db
+      .prepare(`SELECT id FROM mods WHERE slug = ?`)
+      .bind(slug)
+      .first();
+
+    if (!modRow) {
+      throw new Error("Failed to load inserted mod");
+    }
+
+    await db
+      .prepare(
+        `INSERT INTO mod_versions (mod_id, version, r2_key, file_size, changelog, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .bind(modRow.id, "1.0.0", fileKey, file.size, "Initial upload", createdAt)
       .run();
 
     return Response.json({

--- a/index.html
+++ b/index.html
@@ -61,19 +61,45 @@
 
   <script>
     async function loadMods() {
-      try {
-        const res = await fetch('/api/mods');
-        const mods = await res.json();
+      const container = document.getElementById('mod-list');
 
-        const container = document.getElementById('mod-list');
+      try {
+        const allMods = [];
+        let cursor = null;
+
+        do {
+          const params = new URLSearchParams({ limit: '48' });
+          if (cursor) {
+            params.set('cursor', String(cursor));
+          }
+
+          const response = await fetch(`/api/mods?${params.toString()}`);
+          if (!response.ok) {
+            throw new Error(`Failed to load mods: ${response.status}`);
+          }
+
+          const payload = await response.json();
+          const items = Array.isArray(payload) ? payload : payload.items || [];
+          if (!Array.isArray(items)) {
+            throw new Error('Unexpected response payload');
+          }
+
+          allMods.push(...items);
+          cursor = payload && typeof payload.nextCursor === 'number' ? payload.nextCursor : null;
+
+          if (items.length === 0) {
+            cursor = null;
+          }
+        } while (cursor);
+
         container.innerHTML = '';
 
-        if (mods.length === 0) {
+        if (allMods.length === 0) {
           container.textContent = 'No mods published yet.';
           return;
         }
 
-        mods.forEach(mod => {
+        allMods.forEach((mod) => {
           const card = document.createElement('div');
           card.className = 'card';
 
@@ -87,7 +113,7 @@
           container.appendChild(card);
         });
       } catch (err) {
-        document.getElementById('mod-list').textContent = 'Failed to load mods 😢';
+        container.textContent = 'Failed to load mods 😢';
         console.error(err);
       }
     }


### PR DESCRIPTION
## Summary
- fix the mods listing query so date filtering composes correctly with other filters
- make trending ordering robust when rows are missing a latest version timestamp
- harden the upload endpoint with stricter validation, slug sanitisation, and creator checks
- update the landing page to request every page of mods so the full catalog renders

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db097f914c83338b86fc14d72c68c0